### PR TITLE
Update infra.yaml

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 jobs:
-  Build:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -15,17 +15,18 @@ jobs:
       - name: Azure Auth
         uses: azure/login@v1
         with:
-          creds: '{
-            "tenantId": "${{ vars.AZURE_TENANT_ID }}",
-            "subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}",
-            "clientId": "${{ vars.AZURE_CLIENT_ID }}",
-            "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}"
-          }'
+          creds: |
+            {
+              "tenantId": "${{ vars.AZURE_TENANT_ID }}",
+              "subscriptionId": "${{ vars.AZURE_SUBSCRIPTION_ID }}",
+              "clientId": "${{ vars.AZURE_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}"
+            }
 
       - name: Validate
         uses: azure/bicep-deploy@v2
         with:
-          name: 'Identity infrastructure validation'
+          name: 'Identity-infrastructure-validation'
           type: deployment
           operation: validate
           scope: resourceGroup


### PR DESCRIPTION
> [!important]
> I am not sure if this will work like this (because I can't test it locally/with my azure account), but it should fix the ["InvalidDeployment"](https://github.com/slawomirbrys/Identity/actions/runs/14052428172/job/39345110584) while building;

## Summary by GitHub Copilot

This pull request includes several changes to the `.github/workflows/infra.yaml` file to standardize job naming conventions and improve the readability of the Azure credentials.

Standardization and readability improvements:

* Changed the job name from `Build` to `build` to follow a consistent lowercase naming convention.
* Updated the Azure credentials format to use a pipe (`|`) for multiline strings, enhancing readability.
* Modified the name of the validation step from `'Identity infrastructure validation'` to `'Identity-infrastructure-validation'` to use hyphens instead of spaces.